### PR TITLE
[WIP] monadless for doobie's ConnectionIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ val myMonadMonadless = io.monadless.algebird.MonadlessMonad[MyMonad]()
 import monadless._
 ```
 
+### `monadless-doobie`
+
+SBT configuration:
+```
+libraryDependencies += "io.monadless" %% "monadless-doobie" % "0.0.13"
+```
+
+Usage:
+```scala
+// for `doobie.free.connection.ConnectionIO`
+import io.monadless.doobie.MonadlessConnectionIO._
+```
+
 ### Twitter monads
 
 SBT configuration:

--- a/build.sbt
+++ b/build.sbt
@@ -22,14 +22,15 @@ lazy val `monadless` =
       `monadless-stdlib-jvm`, `monadless-stdlib-js`,
       `monadless-cats-jvm`, `monadless-cats-js`, 
       `monadless-monix-jvm`, `monadless-monix-js`, 
-      `monadless-algebird`, `monadless-examples`
+      `monadless-algebird`, `monadless-doobie`,
+      `monadless-examples`
     )
     .dependsOn(
       `monadless-core-jvm`, `monadless-core-js`, 
       `monadless-stdlib-jvm`, `monadless-stdlib-js`,
       `monadless-cats-jvm`, `monadless-cats-js`, 
       `monadless-monix-jvm`, `monadless-monix-js`,
-      `monadless-algebird`
+      `monadless-algebird`, `monadless-doobie`
     )
 
 lazy val `monadless-core` = 
@@ -116,6 +117,18 @@ lazy val `monadless-algebird` = project
       "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
     )
   )
+
+lazy val `monadless-doobie` = project
+  .dependsOn(`monadless-core-jvm`)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.tpolecat" %% "doobie-core" % "0.5.3",
+      "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
+      "com.h2database" % "h2" % "1.4.197" % "test"
+    )
+  )
+
 
 lazy val `monadless-examples` = project
   .dependsOn(`monadless-stdlib-jvm`)

--- a/monadless-doobie/src/main/scala/io/monadless/doobie/MonadlessConnectionIO.scala
+++ b/monadless-doobie/src/main/scala/io/monadless/doobie/MonadlessConnectionIO.scala
@@ -1,0 +1,37 @@
+package io.monadless.doobie
+
+import cats.Applicative
+import doobie.free.connection
+import doobie.free.connection.ConnectionIO
+import io.monadless.Monadless
+import doobie.syntax.monaderror._
+
+trait MonadlessConnectionIO extends Monadless[ConnectionIO] {
+  implicit val applicative = new ConnectionIOApplicative
+
+  def apply[A](f: => A): ConnectionIO[A] = connection.pure(f)
+
+  import cats.implicits._
+
+  def collect[A](l: List[ConnectionIO[A]]): ConnectionIO[List[A]] = l.sequence
+
+  def map[A, B](m: ConnectionIO[A])(f: A => B): ConnectionIO[B] = m.map(f)
+
+  def flatMap[A, B](m: ConnectionIO[A])(f: A => ConnectionIO[B]): ConnectionIO[B] = m.flatMap(f)
+
+  def rescue[A](m: ConnectionIO[A])(pf: PartialFunction[Throwable, ConnectionIO[A]]): ConnectionIO[A] = m.recoverWith(pf)
+
+  def ensure[A](m: ConnectionIO[A])(f: => Unit): ConnectionIO[A] = m.guarantee(connection.pure(f))
+}
+
+object MonadlessConnectionIO$ extends MonadlessConnectionIO
+
+class ConnectionIOApplicative extends Applicative[ConnectionIO] {
+  override def pure[A](x: A): ConnectionIO[A] = connection.pure(x)
+
+  override def ap[A, B](ff: ConnectionIO[A => B])(fa: ConnectionIO[A]): ConnectionIO[B] =
+    for {
+      a <- fa
+      fatob <- ff
+    } yield fatob.apply(a)
+}

--- a/monadless-doobie/src/test/scala/io/monadless/doobie/ConnectionIOMonadlessSpec.scala
+++ b/monadless-doobie/src/test/scala/io/monadless/doobie/ConnectionIOMonadlessSpec.scala
@@ -1,0 +1,90 @@
+package io.monadless.doobie
+
+import cats.effect.IO
+import doobie.free.connection.ConnectionIO
+import doobie.util.transactor.Transactor
+import io.monadless.impl.TestSupport
+import org.scalatest.MustMatchers
+
+class ConnectionIOMonadlessSpec extends org.scalatest.FreeSpec
+  with MustMatchers
+  with MonadlessConnectionIO
+  with TestSupport[ConnectionIO] {
+
+  import doobie.implicits._
+
+  val xa = Transactor.fromDriverManager[IO](
+    "org.h2.Driver",
+    "jdbc:h2:mem:queryspec;DB_CLOSE_DELAY=-1",
+    "sa", ""
+  )
+
+  private def queryInt(i: Int): ConnectionIO[Int] =
+    sql"""select ${i} as result""".query[Int].to[List].map(_.head)
+
+  val one: ConnectionIO[Int] = queryInt(1)
+  val two: ConnectionIO[Int] = queryInt(2)
+
+  override def get[T](m: ConnectionIO[T]): T = m.transact(xa).unsafeRunSync()
+
+  def fail[T]: T = throw new Exception
+
+  "apply" in
+    runLiftTest(1) {
+      unlift(one)
+    }
+
+  "collect" in
+    runLiftTest(3) {
+      unlift(one) + unlift(two)
+    }
+
+  "map" in
+    runLiftTest(2) {
+      unlift(one) + 1
+    }
+
+  "flatMap" in
+    runLiftTest(3) {
+      val a = unlift(one)
+      a + unlift(two)
+    }
+
+  "rescue" - {
+    "success" in
+      runLiftTest(1) {
+        try unlift(one)
+        catch {
+          case e: Throwable => unlift(two)
+        }
+      }
+    "failure" in
+      runLiftTest(1337) {
+        try unlift(two) / fail[Int]
+        catch {
+          case e: Exception => unlift(queryInt(1337))
+        }
+      }
+  }
+
+  "ensure" - {
+    "success" in
+      runLiftTest(1) {
+        var i = 0
+        try unlift(one)
+        finally i += 1
+        i
+      }
+    "failure" in
+      runLiftTest(1) {
+        var i = 0
+        try {
+          try unlift(one) / fail[Int]
+          finally i += 1
+        } catch {
+          case e: Exception => 1
+        }
+        i
+      }
+  }
+}


### PR DESCRIPTION
New feature.

### Problem

This is a monadless instance for a popular pure DB connector doobie https://github.com/tpolecat/doobie

### Solution

Wrote MonadlessConnectionIO

### Notes

One thing i could not find reasons for is:

I've copied tests from the monix.Task monadless instance and with the rescue test originally I had it as

```
"rescue" - {
    "success" in
      runLiftTest(1) {
        try unlift(one)
        catch {
          case e: Throwable => unlift(two)
        }
      }
    "failure" in
      runLiftTest(1337) {
        try fail[Int]
        catch {
          case e: Exception => unlift(queryInt(1337))
        }
      }
  }
```

And this never called `rescue` in `failure`. Chanigng it to 

```
"rescue" - {
    "success" in
      runLiftTest(1) {
        try unlift(one)
        catch {
          case e: Throwable => unlift(two)
        }
      }
    "failure" in
      runLiftTest(1337) {
        try unlift(two) / fail[Int]
        catch {
          case e: Exception => unlift(queryInt(1337))
        }
      }
  }
```
Calls `rescue` properly and makes the code pass.

What am I missing here? Marking the code as `WIP` for that reason. Otherwise i have it in my production code and it works well.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted
