### PR TITLE
bump cats version to 1.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ lazy val `monadless-cats` =
       name := "monadless-cats",
       libraryDependencies ++= Seq(
         "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
-        "org.typelevel" %%% "cats" % "0.9.0"
+        "org.typelevel" %%% "cats-core" % "1.5.0"
       ),
       scoverage.ScoverageKeys.coverageMinimum := 96,
       scoverage.ScoverageKeys.coverageFailOnMinimum := false)

--- a/monadless-cats/src/main/scala/io/monadless/cats/MonadlessApplicative.scala
+++ b/monadless-cats/src/main/scala/io/monadless/cats/MonadlessApplicative.scala
@@ -13,7 +13,7 @@ trait MonadlessApplicative[M[_]] extends Monadless[M] {
     tc.pure(v)
 
   def collect[T](list: List[M[T]])(implicit t: Traverse[List]): M[List[T]] =
-    tc.sequence(list)
+    t.sequence(list)(tc)
 
   def map[T, U](m: M[T])(f: T => U): M[U] =
     tc.map(m)(f)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,4 +23,4 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")


### PR DESCRIPTION
Fixes #issue_number

### Problem

I was hit by classpath issues as I hade cats 1.x.x on CP already

### Solution

Upgrade cats to newest version

### Notes

-

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted
