### PR TITLE
fix an typo in a type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ trait M[A] {
 object M {
 
   // Creates a monad instance with the result of `f`
-  def apply[A](f: => T): M[A]
+  def apply[A](f: => A): M[A]
 
   // Transforms multiple monad instances into one.
   def collect[A](l: List[M[A]]): M[List[A]]


### PR DESCRIPTION
The readme had a typo in a type param