### PR TITLE
travis.yml: build with openjdk8 instead of oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: scala
 scala:
    - 2.11.8
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
 - ./build/build.sh
 after_success:


### PR DESCRIPTION

### Problem

The build for https://github.com/monadless/monadless/pull/44 is running into https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/13

### Solution

That thread suggests that building with openjdk8 instead of oraclejdk8 should fix it.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted
